### PR TITLE
Include Git branch as tag when pushing to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker-compose build --no-cache --force-rm app
-  docker-test:
-    name: Test Docker Compose
-    runs-on: ubuntu-latest
-    env:
-      DB_PORT: 5432
-    steps:
-      - uses: actions/checkout@v3
-      - name: Test the Docker image
-        run: docker-compose up -d app
+        run: docker-compose up --build --force-recreate -d app
   project-build:
     name: Build Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -32,6 +32,7 @@ jobs:
           # Set latest tag for default branch
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
It will always set the Git branch as tag and when the branch is the default one (e.g. main), it will also set as `latest`