### PR TITLE
[RC] Push multiple platforms to Docker Hub

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -23,7 +23,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-          driver-opts: |
-            image=moby/buildkit:master
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -40,9 +37,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
+          platforms: ${{ steps.buildx.outputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -23,7 +23,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/amd64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/amd64/v8,linux/ppc64le,linux/s390x
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -17,8 +17,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          driver-opts: |
+            image=moby/buildkit:master
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
By now, only `linux/arm64` and `linux/amd64` are being pushed. Those ones was being tested in Linux (AWS) and MacOS environments.